### PR TITLE
feat: added support for database static roles and creds

### DIFF
--- a/pipelines/database/get_static_creds.fp
+++ b/pipelines/database/get_static_creds.fp
@@ -1,0 +1,39 @@
+pipeline "get_static_creds" {
+  title       = "Get Static Creds"
+  description = "Retrieves current credentials based on the named static role."
+
+  tags = {
+    type = "featured"
+  }
+
+  param "cred" {
+    type        = string
+    description = local.cred_param_description
+    default     = "default"
+  }
+
+  param "name" {
+    type        = string
+    description = "Specifies the name of the static role to get credentials for."
+  }
+
+  param "mount_path" {
+    type        = string
+    description = "Specifies the mount path of the secret backend."
+    default     = "database"
+  }
+
+  step "http" "get_static_creds" {
+    method = "get"
+    url    = "${credential.vault[param.cred].address}/v1/${param.mount_path}/static-creds/${param.name}"
+
+    request_headers = {
+      "X-Vault-Token" = credential.vault[param.cred].token
+    }
+  }
+
+  output "static_creds" {
+    description = "The current credentials based on the named static role."
+    value       = step.http.get_static_creds.response_body.data
+  }
+}

--- a/pipelines/database/list_static_roles.fp
+++ b/pipelines/database/list_static_roles.fp
@@ -1,0 +1,34 @@
+pipeline "list_static_roles" {
+  title       = "List Static Roles"
+  description = "Retrieves a list of available static roles."
+
+  tags = {
+    type = "featured"
+  }
+
+  param "cred" {
+    type        = string
+    description = local.cred_param_description
+    default     = "default"
+  }
+
+  param "mount_path" {
+    type        = string
+    description = "Specifies the mount path of the secret backend."
+    default     = "database"
+  }
+
+  step "http" "list_static_roles" {
+    method = "get"
+    url    = "${credential.vault[param.cred].address}/v1/${param.mount_path}/static-roles?list=true"
+
+    request_headers = {
+      "X-Vault-Token" = credential.vault[param.cred].token
+    }
+  }
+
+  output "static_roles" {
+    description = "The static roles available."
+    value       = step.http.list_static_roles.response_body.data.keys
+  }
+}


### PR DESCRIPTION
### Checklist
- [ ] Issue(s) linked

We would like to be notified when the access data for the static database expires 14 days in advance. Therefore, I implemented both API endpoints to first list all static roles and then iterate each of them to get detailed information such as the credentials and their expiration date.

Below an example how to use it:

```
pipeline "static_creds_expiry" {

  step "pipeline" "list_static_roles" {
    pipeline = vault.pipeline.list_static_roles
    args = {
      mount_path = "postgres" # in case it differs from the default "database"
    }
  }

  step "pipeline" "get_static_creds" {
    for_each = step.pipeline.list_static_roles.output.static_roles

    pipeline = vault.pipeline.get_static_creds
    args = {
      mount_path = "postgres"  # in case it differs from the default "database"
      name       = each.value
    }
  }

  step "message" "notify" {
    for_each = step.pipeline.get_static_creds
    # Only notify if the TTL is less than 14 days
    if = each.value.output.static_creds.ttl < 1209600

    notifier = notifier.default
    channel  = "#flowpipe"
    text     = "${each.value.output.static_creds.username} has a static credential that will expire in ${each.value.output.static_creds.ttl} seconds."
  }
}
```